### PR TITLE
fix #7

### DIFF
--- a/R/class-spatial.R
+++ b/R/class-spatial.R
@@ -28,7 +28,7 @@ fortify.SpatialPoints <- function(model, data = NULL, ...) {
 #' @export
 fortify.SpatialPointsDataFrame <- function(model, data = NULL, ...) {
   coords <- sp::coordinates(model)
-  data.frame(id=1:nrow(coords), long = coords[, 1], lat = coords[, 2])
+  data.frame(id=row.names(model), long = coords[, 1], lat = coords[, 2])
 }
 
 #' @rdname fortify.SpatialPoints
@@ -49,7 +49,7 @@ spatial_fortify.SpatialPointsDataFrame <- function(x, attrs = NA, ...) {
 
   if(!is.null(attrs)) {
     # add .id column
-    attrs$.id <- 1:nrow(attrs)
+    attrs$.id <- row.names(x)
   }
 
   # call default method
@@ -62,6 +62,7 @@ spatial_fortify.SpatialLinesDataFrame <- function(x, attrs = NA, ...) {
   # override attribute table if present
   if(identical(attrs, NA)) {
     attrs <- x@data
+    row.names(attrs) <- row.names(x)
   }
   # call default method
   spatial_fortify.default(x, attrs, ...)

--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -82,3 +82,15 @@ ggspatial(longlake_waterdf, fill="lightblue") +
    geom_spatial(longlake_depthdf, aes(col=DEPTH.M)) +
    facet_wrap(~NOTES)+
    coord_map()
+
+# check spatial fortify of spatial objects with non-standard row.names
+# SpatialPoints
+nonstandard_sp <- longlake_depthdf
+row.names(nonstandard_sp) <- sample(nrow(nonstandard_sp), replace = FALSE)
+head(spatial_fortify(nonstandard_sp))
+
+# SpatialPolygons
+nonstandard_sp <- longlake_waterdf
+row.names(nonstandard_sp) <- as.character(sample(nrow(nonstandard_sp), replace = FALSE))
+head(spatial_fortify(nonstandard_sp))
+ggspatial(nonstandard_sp, aes(fill = label))

--- a/vignettes/ggspatial.Rmd
+++ b/vignettes/ggspatial.Rmd
@@ -60,7 +60,7 @@ ggplot() +
 
 It is actually not necessary to wrap objects in `fortify()` when passing them to `ggplot()` or `geom_*` or `stat_*` functions; `ggplot2` will do this for you if you should so choose. More likely, if you need the raw data produced by `fortify()`, you will want to calculate this prior to creating the plot anyway. You will notice that the code is slightly repetitive (the mapping is always `aes(long, lat, ...)`) and doesn't allow mapping of attributes that the spatial object may contain.
 
-This package (currently) contains `fortify()` implementations for `SpatialPoints`, `SpatialPointsDataFrame`, and `Raster` objects. The ggplot2 package contains implementations for `Polygon`, `Polygons`, `SpatialPolygons`, `SpatialPolygonsDataFrame`, `Line`, `Lines`, `SpatialLines`, and `SpatialLinesDataFrame`. Creating your own `fortify.ClassName()` function for a spatial object not included in this package is likely all you will need to add this functionality.
+This package (currently) contains `fortify()` implementations for `SpatialPoints`, `SpatialPointsDataFrame`, `SpatialLines`, and `Raster` objects. The ggplot2 package contains implementations for `Polygon`, `Polygons`, `SpatialPolygons`, `SpatialPolygonsDataFrame`, `Line`, `Lines`, and `SpatialLinesDataFrame`.
 
 ## Using spatial_fortify()
 


### PR DESCRIPTION
fixes spatial_fortify when objects have non-standard row.names