### PR TITLE
fix line_width in north_arrow_orienteering

### DIFF
--- a/R/annotation-north-arrow.R
+++ b/R/annotation-north-arrow.R
@@ -254,7 +254,7 @@ north_arrow_orienteering <- function(line_width = 1, line_col = "black", fill = 
       id = arrow_id,
       default.units = "npc",
       gp = grid::gpar(
-        linewidth = line_width,
+        lwd = line_width,
         col = line_col,
         fill = fill
       )


### PR DESCRIPTION
The style north_arrow_orienteering was the only one, where line_width did not change the width of the outline of the arrow. It was a tiny bug in `grid::polygonGrob`, which this pull request fixes.

Now it's possible to paint wonderful thick or thin outlined arrows:
```
library(ggplot2)
library(ggspatial)

load_longlake_data() 

ggplot() +
  layer_spatial(longlake_depthdf) +
  annotation_north_arrow(
    style=north_arrow_orienteering(line_col='red', line_width=5)) 
```
![example](https://user-images.githubusercontent.com/5541490/60509544-75cb5780-9ccd-11e9-8b06-fab45527e48a.png)
