### PR TITLE
Additional documentation for possible maptypes

### DIFF
--- a/R/annotation-map-tile.R
+++ b/R/annotation-map-tile.R
@@ -6,7 +6,7 @@
 #' (e.g., "Copyright OpenStreetMap contributors" when using an
 #' OpenStreetMap-based tile set).
 #'
-#' @param type The map type
+#' @param type The map type (one of that returned by [rosm::osm.types])
 #' @param zoom The zoom level (overrides zoomin)
 #' @param zoomin Delta on default zoom. The default value is designed
 #'   to download fewer tiles than you probably want. Use `-1` or `0` to

--- a/man/annotation_map_tile.Rd
+++ b/man/annotation_map_tile.Rd
@@ -26,7 +26,7 @@ annotation_map_tile(
 GeomMapTile
 }
 \arguments{
-\item{type}{The map type}
+\item{type}{The map type (one of that returned by \link[rosm:osm.types]{rosm::osm.types})}
 
 \item{zoom}{The zoom level (overrides zoomin)}
 
@@ -42,7 +42,7 @@ increase the resolution.}
 
 \item{quiet}{Use \code{quiet = FALSE} to see which URLs are downloaded}
 
-\item{interpolate}{Passed to \code{\link[grid:grid.raster]{grid::rasterGrob()}}}
+\item{interpolate}{Passed to \code{\link[grid:rasterGrob]{grid::rasterGrob()}}}
 
 \item{data, mapping}{Specify data and mapping to use this geom with facets}
 


### PR DESCRIPTION
After unsuccessfully trying different type parameters known from other packages which download osm data, I figured those were not usable with `rosm::osm.image()`. I think it is helpful to have the types in the manual. 