### PR TITLE
Add support for factor/categorical rasters

### DIFF
--- a/R/df-spatial-raster.R
+++ b/R/df-spatial-raster.R
@@ -11,6 +11,19 @@ df_spatial.Raster <- function(x, ..., hjust = 0.5, vjust = 0.5, na.rm = FALSE) {
     raster::values(x)
   )
 
+  ## Ensure that a factor raster's values stay factors in `fused`
+  ## data.frame, taking levels from second column of RAT
+  if (any(raster::is.factor(x))) {
+    for (i in seq_len(nlayers(x))) {
+      if (raster::is.factor(x[[i]])) {
+        rat <- raster::levels(x)[[i]]
+        fused[, i + 2] <- factor(fused[, i + 2],
+                                 levels = rat[, 1],
+                                 labels = rat[, 2])
+      }
+    }
+  }
+
   # set names to be x, y, band1, band2, ...
   nbands <- ncol(fused) - 2
   names(fused) <- c("x", "y", paste0("band", seq_len(nbands)))

--- a/R/df-spatial-raster.R
+++ b/R/df-spatial-raster.R
@@ -11,22 +11,22 @@ df_spatial.Raster <- function(x, ..., hjust = 0.5, vjust = 0.5, na.rm = FALSE) {
     raster::values(x)
   )
 
-  ## Ensure that a factor raster's values stay factors in `fused`
-  ## data.frame, taking levels from second column of RAT
-  if (any(raster::is.factor(x))) {
-    for (i in seq_len(nlayers(x))) {
-      if (raster::is.factor(x[[i]])) {
-        rat <- raster::levels(x)[[i]]
-        fused[, i + 2] <- factor(fused[, i + 2],
-                                 levels = rat[, 1],
-                                 labels = rat[, 2])
-      }
-    }
-  }
-
   # set names to be x, y, band1, band2, ...
   nbands <- ncol(fused) - 2
   names(fused) <- c("x", "y", paste0("band", seq_len(nbands)))
+
+  # Ensure that a factor raster's values stay factors in `fused`
+  # data.frame, taking levels from second column of RAT
+  if (any(raster::is.factor(x))) {
+    band_names <- names(fused)[-1:-2]
+    for (i in seq_along(band_names)) {
+      if (raster::is.factor(x[[i]])) {
+        rat <- raster::levels(x[[i]])[[1]]
+        fused[[band_names[i]]] <-
+          factor(fused[[band_names[i]]], levels = rat[, 1], labels = rat[, 2])
+      }
+    }
+  }
 
   if (na.rm) {
     for (i in seq_len(nbands)) {

--- a/tests/testthat/test-df-spatial-raster.R
+++ b/tests/testthat/test-df-spatial-raster.R
@@ -65,3 +65,27 @@ test_that("na.rm works on df_spatial.Raster()", {
   expect_false(any(is.na(df_finite$band2)))
   expect_false(any(is.na(df_finite$band3)))
 })
+
+test_that("Factor Raster* objects are properly converted", {
+  # Test factor RasterLayer
+  r_num <- raster(nrows = 3, ncols = 3, crs = 4326, xmn = 0, xmx = 3,
+                  ymn = 0, ymx = 3, vals = c(1,2,3,3,1,2,2,3,1))
+  r_fac <- as.factor(r_num)
+  levels(r_fac) <-
+      data.frame(ID = 1:3, landcover = c("grassland", "savannah", "forest"))
+  expect_is(df_spatial(r_num)[["band1"]], "numeric")
+  expect_is(df_spatial(r_fac)[["band1"]], "factor")
+  expect_identical(levels(df_spatial(r_fac)[["band1"]]),
+                   c("grassland", "savannah", "forest"))
+
+  # Test RasterStack with mixed factor and numeric layers
+  s <- stack(r_fac, r_num, r_fac)
+  expect_identical(unname(sapply(df_spatial(s)[-1:-2], class)),
+                   c("factor", "numeric", "factor"))
+
+  # Test factor RasterBrick
+  b <- brick(r_fac, r_fac, r_fac)
+  expect_identical(unname(sapply(df_spatial(b)[-1:-2], class)),
+                   c("factor", "factor", "factor"))
+})
+


### PR DESCRIPTION
This commit makes it possible to plot factor/categorical rasters using
`layer_spatial.Raster()`. It does so by testing whether the supplied
raster is a factor raster and, if it is, using the raster's raster
attribute table (RAT) to convert the appropriate value column(s) in
the data.frame that's ultimately passed along to
`ggplot2::geom_raster()` to a factor. For now, the RAT's first two
columns (its ID column and its first value column) are used to define
the mapping of the raster's values to the appropriate factor labels.

Following is a simple example of the type of plot this edit makes
possible:

```r
library(ggplot2)
library(ggspatial)
library(sf)
library(raster)

lux <- st_read(system.file("external", package = "raster"), "lux") %>%
    st_transform(32632)
r <- raster(extent(lux), resolution = c(3000, 3000))
lux <- rasterize(lux[, c("NAME_2", "NAME_1")], r)

ggplot() + layer_spatial(lux) +
    scale_fill_brewer(palette = "Paired",
                      na.value = NA, na.translate = FALSE,
                      expand = c(0, 0)) +
    labs(fill = "Province")
```