### PR TITLE
annotation_north_arrow() rotation does not work 

### DIFF
--- a/R/annotation-north-arrow.R
+++ b/R/annotation-north-arrow.R
@@ -64,6 +64,7 @@ annotation_north_arrow <- function(mapping = NULL, data = NULL, ...,
       width = width,
       pad_x = pad_x,
       pad_y = pad_y,
+      rotation = rotation,
       style = style
     )
   )


### PR DESCRIPTION
It doesn't pass the argument on. Simple fix. Thanks for this package!