### PR TITLE
Fix annotation_spatial() for ggplot release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: pkgdown
           needs: website

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: covr
 

--- a/R/layer-spatial.R
+++ b/R/layer-spatial.R
@@ -101,7 +101,7 @@ shadow_spatial.default <- function(data, ...) {
 StatSfAnnotation <- ggplot2::ggproto(
   "StatSfAnnotation",
   ggplot2::StatSf,
-  compute_group = function(data, scales) {
+  compute_panel = function(data, scales, coord) {
     data$xmin <- NA_real_
     data$xmax <- NA_real_
     data$ymin <- NA_real_


### PR DESCRIPTION
Closes #114.

``` r
library(ggplot2)
library(ggspatial)
load_longlake_data()

packageVersion("ggplot2")
#> [1] '3.4.2'

ggplot() +
  annotation_spatial(longlake_roadsdf, size = 2, col = "black") +
  layer_spatial(longlake_depthdf, aes(fill = DEPTH_M))
```

![](https://i.imgur.com/VfmLv7P.png)<!-- -->

<sup>Created on 2023-04-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>