### PR TITLE
Add "line" style and "text_pos" argument to annotation_scale()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Updated `load_longlake_data()` to use terra package by default instead of the deprecated raster package
 * Updated example for `layer_spatial()` to avoid error when plotting raster layer
+* Added `"line"` style and `text_pos` argument to `annotatation_scale()`.  
+`annotation_scale(style = "line", width_hint = 0.2)` yields a scale bar line
+with the bar length text above it. 
 
 # ggspatial 1.1.9
 

--- a/man/annotation_scale.Rd
+++ b/man/annotation_scale.Rd
@@ -23,7 +23,8 @@ annotation_scale(
   text_cex = 0.7,
   text_face = NULL,
   text_family = "",
-  tick_height = 0.6
+  tick_height = 0.6,
+  text_pos = NULL
 )
 
 GeomScaleBar
@@ -45,6 +46,9 @@ Must be one of km, m, cm, mi, ft, or in.}
 \item{text_pad, text_cex, text_face, text_family}{Parameters for label}
 
 \item{tick_height}{Height of ticks relative to height of scale bar}
+
+\item{text_pos}{Text position relative to bar, either "\code{above}" or \code{"inside"}
+(towards plot center).}
 }
 \value{
 A ggplot2 layer.
@@ -59,9 +63,9 @@ aesthetics is useful when facets are used to display multiple panels,
 and a different (or missing) scale bar is required in different panels.
 Otherwise, just pass them as arguments to \code{annotation_scale}.
 \itemize{
-\item width_hint: The (suggested) proportion of the plot area which the scalebar should occupy.
+\item width_hint: The (suggested) proportion of the plot width which the scalebar should occupy.
 \item unit_category: Use "metric" or "imperial" units.
-\item style: One of "bar" or "ticks"
+\item style: One of "bar", "ticks", or "line"
 \item location: Where to put the scale bar ("tl" for top left, etc.)
 \item line_col and text_col: Line and text colour, respectively
 }
@@ -74,10 +78,19 @@ cities <- data.frame(
   city = c("Halifax", "Beijing")
 )
 
-ggplot(cities) +
+p <-  ggplot(cities) +
   geom_spatial_point(aes(x, y), crs = 4326) +
-  annotation_scale() +
   coord_sf(crs = 3995)
+
+ # Box
+ p + annotation_scale()
+
+ # Ticks
+ p + annotation_scale(style = "ticks")
+
+ # Line
+ p + annotation_scale(style = "line", width_hint = 0.2)
+
 
 }
 \keyword{datasets}

--- a/tests/testthat/_snaps/annotation-scale/scale-bar-line.svg
+++ b/tests/testthat/_snaps/annotation-scale/scale-bar-line.svg
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODAuNjh8NjM5LjMyfDAuMDB8NTc2LjAw'>
+    <rect x='80.68' y='0.00' width='558.64' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODAuNjh8NjM5LjMyfDAuMDB8NTc2LjAw)'>
+<rect x='80.68' y='0.00' width='558.64' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTExLjUxfDYzMy44NHwyMi43OHw1NDUuMTE='>
+    <rect x='111.51' y='22.78' width='522.33' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTExLjUxfDYzMy44NHwyMi43OHw1NDUuMTE=)'>
+<rect x='111.51' y='22.78' width='522.33' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='135.25' cy='46.53' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='253.96' cy='165.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='372.67' cy='283.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='491.39' cy='402.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='610.10' cy='521.37' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<line x1='118.60' y1='538.03' x2='237.31' y2='538.03' style='stroke-width: 0.75;' />
+<text x='177.95' y='533.77' text-anchor='middle' style='font-size: 8.40px; font-family: sans;' textLength='14.01px' lengthAdjust='spacingAndGlyphs'>1 m</text>
+<rect x='111.51' y='22.78' width='522.33' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='106.58' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-4</text>
+<text x='106.58' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='106.58' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='106.58' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='106.58' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<polyline points='108.77,521.37 111.51,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='108.77,402.66 111.51,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='108.77,283.95 111.51,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='108.77,165.24 111.51,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='108.77,46.53 111.51,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='135.25,547.85 135.25,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='253.96,547.85 253.96,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='372.67,547.85 372.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='491.39,547.85 491.39,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='610.10,547.85 610.10,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='135.25' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='253.96' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='372.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='491.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='610.10' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='372.67' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(93.73,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text x='111.51' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='86.57px' lengthAdjust='spacingAndGlyphs'>scale bar (line)</text>
+</g>
+</svg>

--- a/tests/testthat/test-annotation-scale.R
+++ b/tests/testthat/test-annotation-scale.R
@@ -125,6 +125,15 @@ test_that("annotation scale works as intended", {
       annotation_scale(plot_unit = "m", style = "ticks") +
       ggplot2::coord_fixed()
   )
+
+  expect_doppelganger(
+    "scale bar (line)",
+    ggplot() +
+      ggplot2::geom_point(aes(x, y), data = data.frame(x = 0:4, y = -(0:4))) +
+      annotation_scale(plot_unit = "m", style = "line") +
+      ggplot2::coord_fixed()
+  )
+
 })
 
 test_that("font items are passed on to annotation_scale()", {
@@ -175,3 +184,5 @@ test_that("certain parameters can be passed as aesthetics to show up on differen
       ggplot2::coord_fixed()
   )
 })
+
+


### PR DESCRIPTION
Update `annotation_scale()`:
* Add `text_pos` argument to position the scale bar length text centered above the bar.
* Add `"line"` option to the `style` argument. 
* All existing behavior of the function is unchanged by new arguments and options.